### PR TITLE
Used Json4s instead of Spray-Json

### DIFF
--- a/spray/build.sbt
+++ b/spray/build.sbt
@@ -14,7 +14,7 @@ libraryDependencies ++= {
   Seq(
     "io.spray"            %%  "spray-can"     % sprayV,
     "io.spray"            %%  "spray-routing" % sprayV,
-    "io.spray"            %%  "spray-json"    % "1.3.1",
+    "org.json4s"          %% "json4s-jackson" % "3.2.11",
     "com.typesafe.akka"   %%  "akka-actor"    % akkaV
   )
 }

--- a/spray/src/main/scala/WebServer.scala
+++ b/spray/src/main/scala/WebServer.scala
@@ -6,9 +6,10 @@ import akka.util.Timeout
 import spray.can.Http
 import spray.routing._
 import spray.http._; import MediaTypes._
-import spray.json._
-import spray.json.DefaultJsonProtocol._
-import spray.httpx.SprayJsonSupport._
+import org.json4s._
+import org.json4s.jackson.Serialization.formats
+import spray.httpx.Json4sJacksonSupport
+
 
 import scala.concurrent.duration._
 
@@ -28,16 +29,22 @@ class DemoServiceActor extends Actor with DemoService {
   def receive = runRoute(route)
 }
 
+object Support extends Json4sJacksonSupport {
+  implicit val json4sJacksonFormats = formats(NoTypeHints)
+}
+
 trait DemoService extends HttpService {
+  import Support._
+
   val route =
     path("") {
       get {
-        complete(PrettyPrinter(List(1, 2, 3).toJson))
+        complete(List(1, 2, 3))
       }
     } ~
     path(Segment) { thingy =>
       get {
-        complete(PrettyPrinter(thingy.toJson))
+        complete(thingy)
       }
     }
 }


### PR DESCRIPTION
Unlike spray-json, the marshaller for Json4s correctly handles string responses by default. Also, in general spray-json is too slow to use in actual production sites, although it is of course more than enough for this simple example