### PR TITLE
Adding fintrospect example

### DIFF
--- a/fintrospect/.gitignore
+++ b/fintrospect/.gitignore
@@ -1,0 +1,25 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Scala template
+*.class
+*.log
+
+.idea/
+# sbt specific
+.cache
+.history
+.lib/
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+
+# Scala-IDE specific
+.scala_dependencies
+.worksheet
+
+# ENSIME specific
+.ensime_cache/
+.ensime
+

--- a/fintrospect/README.md
+++ b/fintrospect/README.md
@@ -1,0 +1,14 @@
+###basics
+http://fintrospect.io
+
+Run the `FintrospectServer`, or `sbt run` to start it. The server binds to port 9999.
+
+###endpoints
+- JSON list (using circe) @ http://localhost:9999/
+- echo string input @ http://localhost:9999/echo/<mystring>
+
+###bonus
+- Generated Swagger docs live @ http://localhost:9999/api-docs
+- We can rebind the HTTP contract to a client function, as shown by running `FintrospectClient`:
+ using the path parameter `-->()` to bind a type-safe value into a request. This also works with all parts 
+ of the HTTP contract (body, header, query, form...)

--- a/fintrospect/build.sbt
+++ b/fintrospect/build.sbt
@@ -1,0 +1,10 @@
+name := "fintrospect-example-app"
+
+scalaVersion := "2.11.8"
+
+mainClass in(Test, run) := Some("FintrospectServer")
+
+libraryDependencies ++= Seq(
+  "io.fintrospect" %% "fintrospect-core" % "13.13.0",
+  "io.fintrospect" %% "fintrospect-circe" % "13.13.0"
+)

--- a/fintrospect/src/main/scala/Echo.scala
+++ b/fintrospect/src/main/scala/Echo.scala
@@ -1,0 +1,16 @@
+import com.twitter.finagle.Service
+import com.twitter.finagle.http.Method.Get
+import com.twitter.finagle.http.Request
+import com.twitter.finagle.http.Status.Ok
+import io.fintrospect.RouteSpec
+import io.fintrospect.formats.PlainText.ResponseBuilder.implicits._
+import io.fintrospect.parameters.Path
+
+object Echo {
+  def echo(value: String) = Service.mk { _: Request => Ok(value) }
+
+  val messageParam = Path.string("value")
+  val contract = RouteSpec("echo", "echoes the path string").at(Get) / "echo" / messageParam
+
+  val route = contract bindTo echo
+}

--- a/fintrospect/src/main/scala/FintrospectClient.scala
+++ b/fintrospect/src/main/scala/FintrospectClient.scala
@@ -1,0 +1,8 @@
+import com.twitter.finagle.Http
+import com.twitter.util.Await
+
+object FintrospectClient extends App {
+  val clientFunction = Echo.contract.bindToClient(Http.newService("localhost:9999"))
+
+  println(Await.result(clientFunction(Echo.messageParam --> "bob")).contentString)
+}

--- a/fintrospect/src/main/scala/FintrospectServer.scala
+++ b/fintrospect/src/main/scala/FintrospectServer.scala
@@ -1,0 +1,19 @@
+import com.twitter.finagle.Http
+import com.twitter.finagle.http.filter.Cors
+import com.twitter.finagle.http.filter.Cors.HttpFilter
+import com.twitter.finagle.http.path.Root
+import com.twitter.util.Await
+import io.fintrospect.ModuleSpec
+import io.fintrospect.renderers.swagger2dot0.{ApiInfo, Swagger2dot0Json}
+
+object FintrospectServer extends App {
+
+  private val svc = ModuleSpec(Root, Swagger2dot0Json(ApiInfo("Example app", "1.0")))
+    .withDescriptionPath(_ / "api-docs")
+    .withRoute(Echo.route)
+    .withRoute(JsonList.route)
+    .toService
+
+  Await.ready(Http.serve(":9999", new HttpFilter(Cors.UnsafePermissivePolicy).andThen(svc)))
+}
+

--- a/fintrospect/src/main/scala/JsonList.scala
+++ b/fintrospect/src/main/scala/JsonList.scala
@@ -1,0 +1,14 @@
+import com.twitter.finagle.Service
+import com.twitter.finagle.http.Method.Get
+import com.twitter.finagle.http.Request
+import com.twitter.finagle.http.Status.Ok
+import io.fintrospect.RouteSpec
+import io.fintrospect.formats.Circe.JsonFormat._
+import io.fintrospect.formats.Circe.ResponseBuilder.implicits._
+
+object JsonList {
+
+  val jsonList = Service.mk { _: Request => Ok(array(number(1), number(2), number(3))) }
+
+  val route = RouteSpec("json list", "marshals a list of ints using circe").at(Get) bindTo jsonList
+}


### PR DESCRIPTION
Framework homepage: is http://fintrospect.io 

Saw the post on reddit/r/scala re: web-frameworks, so thought I'd add an example. As well as the usual templating/JSON lib support, there are a few cool features that I don't believe are available elsewhere, such as re-using the HTTP contracts to generate type-safe HTTP clients, and auto-generating Swagger docs with matching Json Schema.

Fintrospect got 5th in JSON latest TechEmpower benchmarks (beating Http4s/Akka/Finch), so hopefully that's good enough to get listed here :)

https://www.techempower.com/benchmarks/#section=data-r13&hw=ph&test=json&l=4ftbsv 