### PR TITLE
Change Akka-HTTP to use HttpApp class to bootstrap

### DIFF
--- a/akka-http/build.sbt
+++ b/akka-http/build.sbt
@@ -4,7 +4,7 @@ version := "0.0.1-SNAPSHOT"
 
 scalaVersion := "2.11.8"
 
-val akkaHttpVersion = "10.0.3"
+val akkaHttpVersion = "10.0.4"
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,

--- a/akka-http/src/main/scala/Main.scala
+++ b/akka-http/src/main/scala/Main.scala
@@ -1,28 +1,12 @@
 package com.example
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.Http
-import akka.http.scaladsl.server.Directives._
-import akka.stream.ActorMaterializer
-
-// import akka.http.scaladsl.server.Route
-// import akka.http.scaladsl.server.RouteResult.route2HandlerFlow
-
-import spray.json._
+import akka.http.scaladsl.server.{HttpApp, Route}
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
-
-import com.typesafe.config.ConfigFactory
-
 import spray.json.DefaultJsonProtocol._
 
-object Main extends App with SprayJsonSupport {
-  val config = ConfigFactory.load()
+object Main extends HttpApp with SprayJsonSupport with App {
 
-  implicit val system = ActorSystem.create()
-  implicit val executionContext = system.dispatcher
-  implicit val materializer = ActorMaterializer()
-
-  lazy val route =
+  def route: Route =
     get {
       pathSingleSlash {
         complete(List(1, 2, 3))
@@ -32,6 +16,5 @@ object Main extends App with SprayJsonSupport {
       }
     }
 
-  Http().bindAndHandle(route, interface = "localhost", port = 8080)
-
+  startServer(host = "localhost", port = 8080)
 }


### PR DESCRIPTION
Recently Akka-HTTP introduced new abstract class `HttpApp` to scrap boilerplate.
See http://doc.akka.io/docs/akka-http/current/scala/http/routing-dsl/HttpApp.html
Bump version to 10.0.4