### PR TITLE
Add SNUnit Scala Native NGINX Unit frontend

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -131,7 +131,17 @@ lazy val uzhttp = (project in file("uzhttp")).settings(
         "org.polynote" %% "uzhttp" % "0.2.5"
       ))
 
+lazy val snunit = (project in file("snunit")).settings(
+      scalaVersion := "2.11.12",
+      libraryDependencies ++= Seq(
+        "com.github.lolgab" %%% "snunit" % "0.0.3",
+        "com.lihaoyi" %%% "upickle" % "1.2.2"
+      ),
+      nativeMode := "release-fast",
+      nativeLTO := "thin")
+      .enablePlugins(ScalaNativePlugin)
+
 lazy val root = (project.in(file(".")).
-  aggregate(`akka-http`, analogweb, unfiltered, `service-container`, http4s, play, scalatra, finch, cask, uzhttp))
+  aggregate(`akka-http`, analogweb, unfiltered, `service-container`, http4s, play, scalatra, finch, cask, uzhttp, snunit))
 
 enablePlugins(ScalatraPlugin)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,3 +10,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.5.0")
 addSbtPlugin("org.scalatra.sbt" % "sbt-scalatra" % "1.0.3")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
+
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.0-M2")

--- a/snunit/src/main/scala/Main.scala
+++ b/snunit/src/main/scala/Main.scala
@@ -1,0 +1,22 @@
+import snunit._
+import upickle.default._
+
+case class Message(message: String)
+
+object Main extends App {
+  implicit val messageRW = macroRW[Message]
+  val server = SyncServerBuilder()
+    .withRequestHandler(_.withPath("/") {
+      _.send(StatusCode.OK, write(List(1, 2, 3)), Seq("Content-type" -> "application/json"))
+    })
+    .withRequestHandler(_.withPath("/json") {
+      _.send(StatusCode.OK, write(Message("Hello, World!")), Seq("Content-type" -> "application/json"))
+    })
+    .withRequestHandler(_.withPath("/plaintext") {
+      _.send(StatusCode.OK, "Hello, World!", Seq("Content-type" -> "text/plain"))
+    })
+    .withRequestHandler(_.send(StatusCode.NotFound, "Not found", Seq.empty))
+    .build()
+
+  server.listen()
+}


### PR DESCRIPTION
It is missing the curl call to add the compiled binary as an application into Unit.

Here some results with h2load, 8081 is SNUnit and 9000 is the akka-http benchmark:
```
lorenzo@MacBook-Pro-di-Lorenzo ~/s/web-frameworks-templates (main)> h2load -n 1000000 -c 100 --h1 http://localhost:8081/json
starting benchmark...
spawning thread #0: 100 total client(s). 1000000 total requests
Application protocol: http/1.1
progress: 10% done
progress: 20% done
progress: 30% done
progress: 40% done
progress: 50% done
progress: 60% done
progress: 70% done
progress: 80% done
progress: 90% done
progress: 100% done

finished in 13.70s, 72977.10 req/s, 12.18MB/s
requests: 1000000 total, 1000000 started, 1000000 done, 1000000 succeeded, 0 failed, 0 errored, 0 timeout
status codes: 1000000 2xx, 0 3xx, 0 4xx, 0 5xx
traffic: 166.89MB (175000000) total, 97.27MB (102000000) headers (space savings 0.00%), 25.75MB (27000000) data
                     min         max         mean         sd        +/- sd
time for request:       67us      9.77ms      1.14ms       583us    78.92%
time for connect:      850us      2.78ms      1.62ms       517us    65.00%
time to 1st byte:     1.74ms      3.83ms      2.89ms       535us    66.00%
req/s           :     729.85     1533.29      910.61      195.70    80.00%
lorenzo@MacBook-Pro-di-Lorenzo ~/s/web-frameworks-templates (main)> h2load -n 1000000 -c 100 --h1 http://localhost:9000/json
starting benchmark...
spawning thread #0: 100 total client(s). 1000000 total requests
Application protocol: http/1.1
progress: 10% done
progress: 20% done
progress: 30% done
progress: 40% done
progress: 50% done
progress: 60% done
progress: 70% done
progress: 80% done
progress: 90% done
progress: 100% done

finished in 14.65s, 68280.73 req/s, 10.48MB/s
requests: 1000000 total, 1000000 started, 1000000 done, 1000000 succeeded, 0 failed, 0 errored, 0 timeout
status codes: 1000000 2xx, 0 3xx, 0 4xx, 0 5xx
traffic: 153.54MB (161000000) total, 94.41MB (99000000) headers (space savings 0.00%), 25.75MB (27000000) data
                     min         max         mean         sd        +/- sd
time for request:       60us    163.27ms      1.46ms      1.20ms    95.66%
time for connect:     1.98ms      5.08ms      3.08ms       806us    72.00%
time to 1st byte:     6.58ms    165.55ms     72.96ms     50.63ms    62.00%
req/s           :     682.82      692.22      685.85        2.57    73.00%
lorenzo@MacBook-Pro-di-Lorenzo ~/s/web-frameworks-templates (main)> h2load -n 1000000 -c 200 --h1 http://localhost:9000/json
starting benchmark...
spawning thread #0: 200 total client(s). 1000000 total requests
Application protocol: http/1.1
progress: 10% done
progress: 20% done
progress: 30% done
progress: 40% done
progress: 50% done

finished in 6.93s, 81587.72 req/s, 12.53MB/s
requests: 1000000 total, 565087 started, 565000 done, 565000 succeeded, 435000 failed, 435000 errored, 0 timeout
status codes: 565000 2xx, 0 3xx, 0 4xx, 0 5xx
traffic: 86.75MB (90965000) total, 53.34MB (55935000) headers (space savings 0.00%), 14.55MB (15255000) data
                     min         max         mean         sd        +/- sd
time for request:       62us    143.65ms      1.37ms      1.32ms    98.69%
time for connect:     4.07ms      6.18ms      5.39ms       514us    62.50%
time to 1st byte:    10.64ms    148.60ms     73.42ms     45.07ms    58.41%
req/s           :       0.00      743.51      411.83      362.29    56.50%
lorenzo@MacBook-Pro-di-Lorenzo ~/s/web-frameworks-templates (main)> h2load -n 1000000 -c 200 --h1 http://localhost:8081/json
starting benchmark...
spawning thread #0: 200 total client(s). 1000000 total requests
Application protocol: http/1.1
progress: 10% done
progress: 20% done
progress: 30% done
progress: 40% done
progress: 50% done
progress: 60% done
progress: 70% done
progress: 80% done
progress: 90% done
progress: 100% done

finished in 12.25s, 81621.17 req/s, 13.62MB/s
requests: 1000000 total, 1000000 started, 1000000 done, 1000000 succeeded, 0 failed, 0 errored, 0 timeout
status codes: 1000000 2xx, 0 3xx, 0 4xx, 0 5xx
traffic: 166.89MB (175000000) total, 97.27MB (102000000) headers (space savings 0.00%), 25.75MB (27000000) data
                     min         max         mean         sd        +/- sd
time for request:       74us     14.85ms      2.11ms      1.06ms    79.30%
time for connect:     1.46ms      5.75ms      3.18ms      1.08ms    64.00%
time to 1st byte:     3.37ms      8.37ms      6.15ms      1.18ms    64.00%
req/s           :     408.23      690.73      486.77       84.13    85.50%
```