### PR TITLE
Upgrade most frameworks to scala 3

### DIFF
--- a/akka-http/src/main/scala/Main.scala
+++ b/akka-http/src/main/scala/Main.scala
@@ -1,29 +1,30 @@
 package com.example
 
+import scala.concurrent.ExecutionContext
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.Directives._
-
-import spray.json._
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import akka.http.scaladsl.model._
+import spray.json._
 
 object Main extends App with SprayJsonSupport {
 
   case class Message(message: String)
 
   object MessageProtocol extends DefaultJsonProtocol {
-    implicit val messageFormat = jsonFormat1(Message)
+    implicit val messageFormat: JsonFormat[Message] = jsonFormat1(Message.apply)
   }
 
-  implicit val system = ActorSystem.create()
-  implicit val executionContext = system.dispatcher
+  implicit val system: ActorSystem = ActorSystem.create()
+  implicit val executionContext: ExecutionContext = system.dispatcher
 
   import MessageProtocol._
 
   lazy val route =
     get {
       pathSingleSlash {
-        complete(List(1, 2, 3))
+        complete(Array(1, 2, 3))
       } ~
         path("json") {
           complete(Message("Hello, World!").toJson)

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,8 @@ name := """web-frameworks-templates"""
 
 version := "0.1.1"
 
-val scalaV = "2.13.12"
+val scala2V = "2.13.12"
+val scalaV = "3.3.1"
 
 val akkaHttpVersion = "10.5.2"
 val http4sVersion = "0.23.13"
@@ -28,7 +29,7 @@ lazy val cask = (project in file("cask")).settings(
 )
 
 lazy val finatra = (project in file("finatra")).settings(
-  scalaVersion := scalaV,
+  scalaVersion := scala2V,
   libraryDependencies ++= Seq(
     "com.twitter" %% "finatra-http-server" % "22.7.0"
   )
@@ -56,7 +57,7 @@ lazy val play = (project in file("play"))
     scalacOptions += s"-Wconf:src=${target.value}/.*:s",
     libraryDependencies ++= Seq(
       guice,
-      "com.typesafe.play" %% "play-json" % "2.9.3"
+      "org.playframework" %% "play-json" % "3.0.1"
     )
   )
   .enablePlugins(PlayScala)
@@ -67,7 +68,7 @@ lazy val scalatra = (project in file("scalatra")).settings(
   libraryDependencies ++= Seq(
     "org.scalatra" %% "scalatra-javax" % ScalatraVersion,
     "org.scalatra" %% "scalatra-json" % "3.0.0-M5-javax",
-    "org.json4s" %% "json4s-jackson" % "4.0.1",
+    "org.json4s" %% "json4s-jackson" % "4.0.7",
     "ch.qos.logback" % "logback-classic" % "1.2.11" % "runtime",
     "org.eclipse.jetty" % "jetty-webapp" % "9.4.48.v20220622" % "container;compile",
     "javax.servlet" % "javax.servlet-api" % "3.1.0" % "provided"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,13 +2,13 @@ ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" 
 
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.1")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.5.0")
+addSbtPlugin("org.playframework.twirl" % "sbt-twirl" % "2.0.3")
 addSbtPlugin("org.scalatra.sbt" % "sbt-scalatra" % "1.0.3")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")


### PR DESCRIPTION
Finatra doesnt support scala 3, so no luck yet.  
I did try to set it to `("com.twitter" %% "finatra-http-server" % "22.7.0").cross(CrossVersion.for3Use2_13)`
but got some errors which I dont know how to resolve:
```
sbt:finatra> run
[info] compiling 2 Scala sources to C:\projects\tmp\web-frameworks-templates\finatra\target\scala-3.3.1\classes ...
[error] -- [E171] Type Error: C:\projects\tmp\web-frameworks-templates\finatra\src\main\scala\AController.scala:10:11
[error] 10 |  get("/") { (_: Request) =>
[error]    |  ^
[error]    |not enough arguments for method get in trait RouteDSL: (implicit
[error]    |  evidence$4: reflect.runtime.universe.TypeTag[com.twitter.finagle.http.Request]
[error]    |    ,
[error]    |evidence$5:
[error]    |  reflect.runtime.universe.TypeTag[
[error]    |    com.twitter.finatra.http.response.EnrichedResponse]
[error]    |): Unit
[error] 11 |    response.created(List(1, 2, 3))
[error] 12 |  }
```